### PR TITLE
fix: resolves bad import name

### DIFF
--- a/test/priority-queue.test.js
+++ b/test/priority-queue.test.js
@@ -1,4 +1,4 @@
-import PriorityQueue from '../src/priority-queue';
+import PriorityQueue from '../src/priority-queue-rewrite';
 
 
 describe('Priority Queue happy path unit tests', () => {


### PR DESCRIPTION
Forgot to change this import statement when I moved the file to its new name. A good illustration of an issue that automated CI tests resolve.