### PR TITLE
chore: add original priority queue file back

### DIFF
--- a/src/priority-queue-original.js
+++ b/src/priority-queue-original.js
@@ -1,0 +1,60 @@
+/**
+ * A priority queue stores a list of items but each can have a numeric priority value.
+ * Items with a higher priority are dequeued before items with a lower priority.
+ * Implemented as a hash of arrays where the hash keys are priority values.
+ */
+function PriorityQueue(size) {
+	this.store = {};	// keys are priorities, values are arrays of elements
+	this.count = 0;
+
+	// adds an item
+	// priority must be an integer (higher value has higher priority)
+	this.add = function(value, priority) {
+		if (this.store[priority] == undefined)
+			this.store[priority] = [];
+
+		this.store[priority].push(value);
+		this.count++;
+	};
+
+	// returns the oldest-added value with the highest priority
+	this.Pop = function() {
+		maxKey = Math.max(Object.keys(this.store));
+		this.count--;
+		return this.store[maxKey].shift();
+	};
+
+	this.length = function() {
+		return this.count;
+	}
+}
+
+PriorityQueue.prototype.get_all_priorities = function() {
+	return Object.keys(this.store);
+}
+
+// iterates through all the queue elements in priority-then-FIFO order
+PriorityQueue.prototype.forEach = function(callback) {
+	var keys = Object.keys(this.store).sort();
+
+	for (var a = keys.length; a > 0; a--) {
+		for (var b = 0; b < this.store[a].length; b++)
+			callback(this.store[a][b]);
+	}
+}
+
+PriorityQueue.prototype.changePriority = function(value, newPriority) {
+	var foundItem = false;
+
+	this.store.forEach(function(bucket) {
+		bucket.forEach(function(item, index) {
+			if (item === value) {
+				bucket.splice(index, 1);  // remove the item
+				this.add(value, newPriority);
+				foundItem = true;
+				return false;  // early exit from forEach
+			}
+		});
+		if (foundItem) return false;
+	});
+}


### PR DESCRIPTION
This is the original priority queue from [here](https://gist.github.com/sharn-tempo/c8e0b04c44ad4c1fcc9e29a75509feaa). What follows is my feedback on it to an imaginary colleague. 

In a normal work environment I would make some of these comments in private, to give my colleague a chance to catch any glaring errors on their own. If someone is stretching themselves technically, then the last you want to do is embarrass them. 